### PR TITLE
Allow user to override the catch-error response builder class

### DIFF
--- a/src/responseBuilderHandler.js
+++ b/src/responseBuilderHandler.js
@@ -2,7 +2,7 @@
 
 var ResponseBuilder = require('./ResponseBuilder');
 
-module.exports = function(promiseReturningHandlerFn, request, cb) {
+module.exports = function(promiseReturningHandlerFn, request, cb, CustomRespBuilderClass) {
    promiseReturningHandlerFn()
       .then(function(respBuilder) {
          // eslint-disable-next-line no-console
@@ -10,7 +10,8 @@ module.exports = function(promiseReturningHandlerFn, request, cb) {
          cb(undefined, respBuilder.toResponse(request));
       })
       .catch(function(err) {
-         var respBuilder = new ResponseBuilder(request).error();
+         var RB = CustomRespBuilderClass || ResponseBuilder,
+             respBuilder = new RB().error();
 
          // eslint-disable-next-line no-console
          console.log('ERROR:', err, err.stack);

--- a/tests/responseBuilderHandler.test.js
+++ b/tests/responseBuilderHandler.test.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore'),
     Q = require('q'),
+    Class = require('class.extend'),
     sinon = require('sinon'),
     expect = require('expect.js'),
     Request = require('../src/Request'),
@@ -42,11 +43,11 @@ describe('responseBuilderHandler', function() {
       handler(fn, req, cb);
    });
 
-   it('uses a response builder to build an error response for any error that is thrown', function(done) {
+   describe('error handling', function() {
       var expectedErr = new Error('ExpectedThisError'),
-          fn, cb;
+          rejectWithErrorFn;
 
-      fn = function() {
+      rejectWithErrorFn = function() {
          var def = Q.defer();
 
          setTimeout(function() {
@@ -56,13 +57,46 @@ describe('responseBuilderHandler', function() {
          return def.promise;
       };
 
-      cb = function(err, resp) {
-         expect(err).to.be(undefined);
-         expect(resp).to.eql(respBuilder.error().toResponse(req));
-         done();
-      };
+      it('uses a response builder to build an error response for any error that is thrown', function(done) {
+         var cb;
 
-      handler(fn, context, cb);
+         cb = function(err, resp) {
+            expect(err).to.be(undefined);
+            expect(resp).to.eql(respBuilder.error().toResponse(req));
+            done();
+         };
+
+         handler(rejectWithErrorFn, req, cb);
+      });
+
+      it('allows a custom response builder class to be used when it creates a response for an otherwise uncaught error', function(done) {
+         var toResponseStub = sinon.stub(),
+             errorStub = sinon.stub(),
+             CustomResponseBuilder, cb;
+
+         CustomResponseBuilder = Class.extend({
+            error: function() {
+               errorStub.apply(this, arguments);
+               return this;
+            },
+            toResponse: toResponseStub,
+         });
+
+         toResponseStub.returns('this is the custom response');
+
+         cb = function(err, resp) {
+            expect(err).to.be(undefined);
+            expect(resp).to.eql('this is the custom response');
+            sinon.assert.calledOnce(errorStub);
+            sinon.assert.calledWithExactly(errorStub);
+            sinon.assert.calledOnce(toResponseStub);
+            sinon.assert.calledWithExactly(toResponseStub, req);
+            done();
+         };
+
+         handler(rejectWithErrorFn, req, cb, CustomResponseBuilder);
+      });
+
    });
 
 });


### PR DESCRIPTION
If a user utilizes a custom response builder class in their API code, it is returned from the main function passed to the handler. However, if the function throws an error, the handler is forced to create its own response builder since the main function did not resolve a promise containing a response builder. In that case, the user could not specify what response headers to add, or how to format an error, etc. Now they optionally can provide the handler with their own response builder class that will be used in place of the default class.