### PR TITLE
Export CONTENT_TYPE_* consts on SilvermineResponseBuilder

### DIFF
--- a/src/ResponseBuilder.js
+++ b/src/ResponseBuilder.js
@@ -3,10 +3,7 @@
 var _ = require('underscore'),
     Class = require('class.extend'),
     APIError = require('./APIError'),
-    CONTENT_TYPE_JSON = 'application/json;charset=UTF-8',
-    CONTENT_TYPE_JSONP = 'text/javascript;charset=UTF-8',
-    CONTENT_TYPE_RSS = 'application/rss+xml',
-    CONTENT_TYPE_HTML = 'text/html;charset=UTF-8';
+    CONTENT_TYPES = require('./contentTypes');
 
 module.exports = Class.extend({
 
@@ -17,7 +14,7 @@ module.exports = Class.extend({
       this._isJSONPSupported = false;
       this._cacheDurationSeconds = 0;
       this._errors = [];
-      this.contentType(CONTENT_TYPE_JSON);
+      this.contentType(CONTENT_TYPES.CONTENT_TYPE_JSON);
    },
 
    status: function(status) {
@@ -126,12 +123,12 @@ module.exports = Class.extend({
    },
 
    rss: function(body) {
-      this.contentType(CONTENT_TYPE_RSS);
+      this.contentType(CONTENT_TYPES.CONTENT_TYPE_RSS);
       return this.body(body);
    },
 
    html: function(body) {
-      this.contentType(CONTENT_TYPE_HTML);
+      this.contentType(CONTENT_TYPES.CONTENT_TYPE_HTML);
       return this.body(body);
    },
 
@@ -190,7 +187,7 @@ module.exports = Class.extend({
       if (req.hasQueryParam(this._jsonpQueryParamName) && this._isValidJSONPCallback(req.query(this._jsonpQueryParamName))) {
          callback = req.query(this._jsonpQueryParamName);
 
-         this.contentType(CONTENT_TYPE_JSONP);
+         this.contentType(CONTENT_TYPES.CONTENT_TYPE_JSONP);
          this._body = 'typeof ' + callback + ' === \'function\' && ' + callback + '(' + JSON.stringify(this._body) + ');';
       }
    },
@@ -201,7 +198,4 @@ module.exports = Class.extend({
 
 });
 
-module.exports.CONTENT_TYPE_JSON = CONTENT_TYPE_JSON;
-module.exports.CONTENT_TYPE_JSONP = CONTENT_TYPE_JSONP;
-module.exports.CONTENT_TYPE_RSS = CONTENT_TYPE_RSS;
-module.exports.CONTENT_TYPE_HTML = CONTENT_TYPE_HTML;
+_.extend(module.exports, CONTENT_TYPES);

--- a/src/SilvermineResponseBuilder.js
+++ b/src/SilvermineResponseBuilder.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var RB = require('./ResponseBuilder');
+var _ = require('underscore'),
+    RB = require('./ResponseBuilder'),
+    CONTENT_TYPES = require('./contentTypes');
 
 module.exports = RB.extend({
 
@@ -29,3 +31,5 @@ module.exports = RB.extend({
    },
 
 });
+
+_.extend(module.exports, CONTENT_TYPES);

--- a/src/contentTypes.js
+++ b/src/contentTypes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+   CONTENT_TYPE_JSON: 'application/json;charset=UTF-8',
+   CONTENT_TYPE_JSONP: 'text/javascript;charset=UTF-8',
+   CONTENT_TYPE_RSS: 'application/rss+xml',
+   CONTENT_TYPE_HTML: 'text/html;charset=UTF-8',
+};

--- a/tests/ResponseBuilder.test.js
+++ b/tests/ResponseBuilder.test.js
@@ -480,4 +480,11 @@ describe('ResponseBuilder', function() {
 
    });
 
+   it('exposes the content type constants', function() {
+      expect(ResponseBuilder.CONTENT_TYPE_JSON).to.be('application/json;charset=UTF-8');
+      expect(ResponseBuilder.CONTENT_TYPE_JSONP).to.be('text/javascript;charset=UTF-8');
+      expect(ResponseBuilder.CONTENT_TYPE_RSS).to.be('application/rss+xml');
+      expect(ResponseBuilder.CONTENT_TYPE_HTML).to.be('text/html;charset=UTF-8');
+   });
+
 });

--- a/tests/SilvermineResponseBuilder.test.js
+++ b/tests/SilvermineResponseBuilder.test.js
@@ -63,4 +63,11 @@ describe('SilvermineResponseBuilder', function() {
       });
    });
 
+   it('exposes the content type constants', function() {
+      expect(ResponseBuilder.CONTENT_TYPE_JSON).to.be('application/json;charset=UTF-8');
+      expect(ResponseBuilder.CONTENT_TYPE_JSONP).to.be('text/javascript;charset=UTF-8');
+      expect(ResponseBuilder.CONTENT_TYPE_RSS).to.be('application/rss+xml');
+      expect(ResponseBuilder.CONTENT_TYPE_HTML).to.be('text/html;charset=UTF-8');
+   });
+
 });


### PR DESCRIPTION
[`class.extend`][1] does [not copy any properties outside the class' `prototype`][2]  when creating a subclass. This thus makes it so `ResponseBuilder` has the `CONTENT_TYPE_*` exports while `SilvermineResponseBuilder` lacks them. This commit is to make sure these consts are available on the `SilvermineResponseBuilder` subclass.

[1]: https://github.com/allenhwkim/class.extend
[2]: https://github.com/allenhwkim/class.extend/blob/9462f307a2c1c073de1312a28f2a5d20f297e183/lib/class.js#L51-L62