### PR TITLE
BREAKING: Correct the capitalization on ResponseBuilder export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ EXPORTABLE_RESOURCES = {
    Request: './Request',
    APIError: './APIError',
    JWTSecuredRequest: './JWTSecuredRequest',
-   Responsebuilder: './ResponseBuilder',
+   ResponseBuilder: './ResponseBuilder',
    SilvermineResponseBuilder: './SilvermineResponseBuilder',
    responseBuilderHandler: './responseBuilderHandler',
    JWTValidator: './JWTValidator',


### PR DESCRIPTION
If you have been including `ResponseBuilder` using the export `Responsebuilder`, with this commit you will now need to include it using `ResponseBuilder`.