### PR TITLE
Add request logging

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -1,17 +1,36 @@
 'use strict';
 
 var _ = require('underscore'),
-    Class = require('class.extend');
+    Class = require('class.extend'),
+    DEFAULT_OPTS;
+
+DEFAULT_OPTS = {
+   logRequest: true,
+};
 
 module.exports = Class.extend({
 
-   init: function(evt, context) {
+   init: function(evt, context, opts) {
       this._started = new Date().getTime();
       this._event = evt;
       this._context = context;
       this._query = this._event.queryStringParameters || {};
       this._pathParams = this._event.pathParameters || {};
       this._headers = this._event.headers || {};
+      this._opts = _.extend({}, DEFAULT_OPTS, opts);
+
+      if (this._opts.logRequest) {
+         this.logRequest(_.extend({
+            event: 'api-request',
+            path: evt.path,
+            queryParams: this._query,
+         }, this._opts.additionalRequestLoggingData));
+      }
+   },
+
+   logRequest: function(reqObj) {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(reqObj));
    },
 
    _parseBody: function() {

--- a/tests/Request.test.js
+++ b/tests/Request.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Q = require('q'),
+    sinon = require('sinon'),
     expect = require('expect.js'),
     Request = require('../src/Request');
 
@@ -385,6 +386,53 @@ describe('Request', function() {
 
       it('returns null when the body is not valid JSON', function() {
          runTest({ body: '{foo:bar}', headers: { 'content-type': 'application/json' } }, null);
+      });
+
+   });
+
+
+   describe('request logging', function() {
+      var logRequestStub;
+
+      beforeEach(function() {
+         logRequestStub = sinon.stub(Request.prototype, 'logRequest');
+      });
+
+      afterEach(function() {
+         logRequestStub.restore();
+      });
+
+      it('logs the request on initial creation', function() {
+         // eslint-disable-next-line no-new
+         new Request({ path: '/path', queryStringParameters: { key: 'value' } });
+         sinon.assert.calledOnce(logRequestStub);
+         sinon.assert.calledWith(logRequestStub, {
+            event: 'api-request',
+            path: '/path',
+            queryParams: { key: 'value' },
+         });
+      });
+
+      it('doesn\'t log the request when request logging is disabled', function() {
+         // eslint-disable-next-line no-new
+         new Request({ path: '/path', queryStringParameters: { key: 'value' } }, undefined, { logRequest: false });
+         sinon.assert.notCalled(logRequestStub);
+      });
+
+      it('logs additional data when provided', function() {
+         // eslint-disable-next-line no-new
+         new Request({ path: '/path', queryStringParameters: { key: 'value' } }, undefined, {
+            additionalRequestLoggingData: {
+               xrayTraceID: 'trace-id',
+            },
+         });
+         sinon.assert.calledOnce(logRequestStub);
+         sinon.assert.calledWith(logRequestStub, {
+            event: 'api-request',
+            path: '/path',
+            queryParams: { key: 'value' },
+            xrayTraceID: 'trace-id',
+         });
       });
 
    });


### PR DESCRIPTION
This commit adds an `api-request` event that is logged on the creation of every
`Request`. This "event" is a JSON string of the format:

```json
{
   "event": "api-request",
   "path": "/request/path",
   "queryParams": {
      "key": "value"
   }
}
```

To disable this functionality, please pass the option `logRequest` with a value
of `false` on the initialization of a `Request` object.