### PR TITLE
Add helper functions to ResponseBuilder

### DIFF
--- a/src/ResponseBuilder.js
+++ b/src/ResponseBuilder.js
@@ -52,6 +52,10 @@ module.exports = Class.extend({
       return this;
    },
 
+   getCacheDurationInSeconds: function() {
+      return this._cacheDurationSeconds;
+   },
+
    cacheForSeconds: function(s) {
       this._cacheDurationSeconds = Math.max(0, s);
       return this;

--- a/src/ResponseBuilder.js
+++ b/src/ResponseBuilder.js
@@ -125,6 +125,10 @@ module.exports = Class.extend({
       return this.err(title || 'Not implemented', detail, 501, true);
    },
 
+   serviceUnavailable: function(title, detail) {
+      return this.err(title || 'Service unavailable', detail, 503, true);
+   },
+
    rss: function(body) {
       this.contentType(CONTENT_TYPE_RSS);
       return this.body(body);

--- a/src/ResponseBuilder.js
+++ b/src/ResponseBuilder.js
@@ -139,6 +139,19 @@ module.exports = Class.extend({
       return this.body(body);
    },
 
+   okayOrNotFound: function(body, contentType) {
+      if (body) {
+         if (contentType) {
+            this.contentType(contentType);
+         }
+         this.body(body);
+      } else {
+         this.notFound();
+      }
+
+      return this;
+   },
+
    toResponse: function(req) {
       this._updateBodyWithErrors();
       this._updateForJSONP(req);

--- a/tests/ResponseBuilder.test.js
+++ b/tests/ResponseBuilder.test.js
@@ -305,6 +305,7 @@ describe('ResponseBuilder', function() {
          { name: 'unsupportedMediaType', title: 'Can not return requested media type', statusCode: 415 },
          { name: 'serverError', title: 'Internal error', statusCode: 500 },
          { name: 'notImplemented', title: 'Not implemented', statusCode: 501 },
+         { name: 'serviceUnavailable', title: 'Service unavailable', statusCode: 503 },
       ];
 
       _.each(errorFunctions, function(ef) {

--- a/tests/ResponseBuilder.test.js
+++ b/tests/ResponseBuilder.test.js
@@ -481,4 +481,51 @@ describe('ResponseBuilder', function() {
 
    });
 
+
+   describe('okayOrNotFound', function() {
+
+      function runTest(body, contentType, expectedStatusCode, expectedContentType, expectedBody) {
+         var resp;
+
+         resp = rb.toResponse(req);
+         expect(resp.body).to.eql(JSON.stringify({}));
+         expect(rb.okayOrNotFound(body, contentType)).to.eql(rb);
+
+         resp = rb.toResponse(req);
+         expect(resp.statusCode).to.eql(expectedStatusCode);
+         expect(rb.toResponse(req).headers['Content-Type']).to.be(expectedContentType);
+         expect(resp.body).to.eql(expectedBody);
+      }
+
+      it('sets the body and content type when both are provided', function() {
+         var body = '<html />';
+
+         rb.contentType(ResponseBuilder.CONTENT_TYPE_XML);
+         runTest(body, ResponseBuilder.CONTENT_TYPE_HTML, 200, ResponseBuilder.CONTENT_TYPE_HTML, body);
+      });
+
+      it('only sets the body when a valid body is provided, but not a content type', function() {
+         var body = { test: 'data' };
+
+         rb.contentType(ResponseBuilder.CONTENT_TYPE_JSON);
+         runTest(body, undefined, 200, ResponseBuilder.CONTENT_TYPE_JSON, JSON.stringify(body));
+      });
+
+      it('configures the response for "not found" when no body was given', function() {
+         var resp;
+
+         rb.contentType(ResponseBuilder.CONTENT_TYPE_XML);
+
+         resp = rb.toResponse(req);
+         expect(resp.body).to.eql(JSON.stringify({}));
+         expect(rb.okayOrNotFound(undefined, ResponseBuilder.CONTENT_TYPE_HTML)).to.eql(rb);
+
+         resp = rb.toResponse(req);
+         expect(resp.statusCode).to.eql(404);
+         expect(rb.toResponse(req).headers['Content-Type']).to.be(ResponseBuilder.CONTENT_TYPE_XML);
+         expect(resp.body).to.be.a('string');
+      });
+
+   });
+
 });

--- a/tests/ResponseBuilder.test.js
+++ b/tests/ResponseBuilder.test.js
@@ -245,6 +245,25 @@ describe('ResponseBuilder', function() {
 
       });
 
+      describe('getCacheDurationInSeconds', function() {
+
+         it('returns the correct caching duration when set using seconds', function() {
+            rb.cacheForSeconds(25);
+            expect(rb.getCacheDurationInSeconds()).to.eql(25);
+         });
+
+         it('returns the correct caching duration when set using minutes', function() {
+            rb.cacheForMinutes(2);
+            expect(rb.getCacheDurationInSeconds()).to.eql(120);
+         });
+
+         it('returns the correct caching duration when set using hours', function() {
+            rb.cacheForHours(3);
+            expect(rb.getCacheDurationInSeconds()).to.eql(10800);
+         });
+
+      });
+
       describe('toResponse', function() {
 
          it('erases any caches set for non-GET requests', function() {


### PR DESCRIPTION
This PR is to add the following helpers to ResponseBuilder:

- `getCacheDurationInSeconds`—Provides an official way to get the cache duration, e.g. for unit testing
- `serviceUnavailable`—A 503 response response helper
- `okayOrNotFound`—Sets the `body` and content type, if the given `body` exists. Otherwise this function will configure the response for "not found".