### PR TITLE
Refs #17 Ignore params in the Content-Type header when checking for a JSON request body

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -36,7 +36,7 @@ module.exports = Class.extend({
    _parseBody: function(throwError) {
       // By default we just squash any errors while parsing the body, but if the user
       // wants an error to be thrown, they can pass a flag to indicate this.
-      if (this.header('Content-Type') === 'application/json') {
+      if (this._getContentTypeEssence() === 'application/json') {
          try {
             return JSON.parse(this._event.body);
          } catch(err) {
@@ -48,6 +48,20 @@ module.exports = Class.extend({
       }
 
       return null;
+   },
+
+   /**
+    * Returns the type and subtype, e.g. 'application/json', of the MIME type found in the
+    * Content-Type header.
+    *
+    * @see https://mimesniff.spec.whatwg.org/#mime-type-essence
+    * @return {string} The essence of the MIME or `undefined` if the Content-Type header
+    * is not found
+    */
+   _getContentTypeEssence: function() {
+      var contentType = this.header('Content-Type');
+
+      return _.isString(contentType) ? contentType.replace(/;.*/, '').trim().toLowerCase() : undefined;
    },
 
    getEvent: function() {

--- a/tests/Request.test.js
+++ b/tests/Request.test.js
@@ -398,6 +398,10 @@ describe('Request', function() {
          runTest({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } }, body);
       });
 
+      it('parses a JSON body correctly when a charset is included in the Content-Type', function() {
+         runTest({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json; charset=UTF-8' } }, body);
+      });
+
       it('returns null when there are no headers', function() {
          runTest({ body: JSON.stringify(body) }, null);
       });
@@ -420,6 +424,47 @@ describe('Request', function() {
 
       it('returns null when the body is not valid JSON', function() {
          runTest({ body: '{foo:bar}', headers: { 'content-type': 'application/json' } }, null);
+      });
+
+   });
+
+
+   describe('_getContentTypeEssence', function() {
+
+      function runTest(contentType, expectedOutput) {
+         var req = new Request({ headers: { 'Content-Type': contentType } });
+
+         expect(req._getContentTypeEssence()).to.be(expectedOutput);
+      }
+
+      it('returns undefined when Content-Type header is missing', function() {
+         var req = new Request({ headers: {} });
+
+         expect(req._getContentTypeEssence()).to.be(undefined);
+      });
+
+      it('handles an empty Content-Type header', function() {
+         runTest('', '');
+      });
+
+      it('parses a basic JSON MIME type', function() {
+         runTest('application/json', 'application/json');
+      });
+
+      it('parses a JSON MIME type with charset', function() {
+         runTest('application/json; charset=UTF-8', 'application/json');
+      });
+
+      it('parses a MIME type with funky spacing', function() {
+         runTest(' application/json   ; charset=UTF-8 ', 'application/json');
+      });
+
+      it('lowercases a MIME type with mixed case', function() {
+         runTest('Application/JSON', 'application/json');
+      });
+
+      it('parses a MIME type with extra parameters', function() {
+         runTest('text/html;charset=ascii;extra=stuff', 'text/html');
       });
 
    });


### PR DESCRIPTION
This PR is to fix the issue noted in #17.