### PR TITLE
Make JWTSecuredRequest pass opts to Request

### DIFF
--- a/src/JWTSecuredRequest.js
+++ b/src/JWTSecuredRequest.js
@@ -6,8 +6,8 @@ var _ = require('underscore'),
 
 module.exports = Request.extend({
 
-   init: function(evt, context) {
-      this._super(evt, context);
+   init: function(evt, context, opts) {
+      this._super(evt, context, opts);
       this._token = false;
    },
 


### PR DESCRIPTION
This makes it possible to pass `{ logRequest: false }` to a JWTSecuredRequest to disable the request logging added in f715d282a6edb649e5479b54870fe1a728de6443