### PR TITLE
Application Load Balancer support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,6 +1288,11 @@
         "sshpk": "1.13.1"
       }
     },
+    "http-status-codes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
+      "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "sinon": "1.17.7",
     "underscore": "1.8.3",
     "uuid": "3.2.1"
+  },
+  "dependencies": {
+    "http-status-codes": "1.3.0"
   }
 }


### PR DESCRIPTION
Since AWS added support for Application Load Balancers to call Lambda
functions, it is possible to have a set of functions that are called by
both API Gateway and ALB. There are a few minor differences in the
output format needed for ALB, and this commit makes it so that the utils
can support both output formats simultaneously.