### PR TITLE
Refs #22 Mostly revert "Fix "console.error is not a function" on newer versions of node"

### DIFF
--- a/src/ResponseBuilder.js
+++ b/src/ResponseBuilder.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore'),
-    log = console.log.bind(console), // eslint-disable-line no-console
     codes = require('http-status-codes'),
     Class = require('class.extend'),
     APIError = require('./APIError'),
@@ -205,7 +204,7 @@ module.exports = Class.extend({
          this.body(_.map(this._errors, function(err) {
             var o = err.toResponseObject();
 
-            log('API response includes error: %j', o);
+            console.log('API response includes error: %j', o); // eslint-disable-line no-console
             return o;
          }));
       }

--- a/src/responseBuilderHandler.js
+++ b/src/responseBuilderHandler.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var Q = require('q'),
-    ResponseBuilder = require('./ResponseBuilder'),
-    log = console.log.bind(console); // eslint-disable-line no-console
+    ResponseBuilder = require('./ResponseBuilder');
 
 /**
  * In our APIs, we often have errors that are several promises deep, and without this,
@@ -15,14 +14,16 @@ Q.longStackSupport = true;
 module.exports = function(promiseReturningHandlerFn, request, cb, CustomRespBuilderClass) {
    Q.promised(promiseReturningHandlerFn)()
       .then(function(respBuilder) {
-         log('completed with %s millis left', request.getContext().getRemainingTimeInMillis());
+         // eslint-disable-next-line no-console
+         console.log('completed with %s millis left', request.getContext().getRemainingTimeInMillis());
          cb(undefined, respBuilder.toResponse(request));
       })
       .catch(function(err) {
          var RB = CustomRespBuilderClass || ResponseBuilder,
              respBuilder = new RB().serverError().rb();
 
-         log('ERROR:', err, err.stack);
+         // eslint-disable-next-line no-console
+         console.log('ERROR:', err, err.stack);
          cb(undefined, respBuilder.toResponse(request));
       })
       .done();

--- a/tests/responseBuilderHandler.test.js
+++ b/tests/responseBuilderHandler.test.js
@@ -12,23 +12,11 @@ var _ = require('underscore'),
 
 describe('responseBuilderHandler', function() {
    var context = { getRemainingTimeInMillis: _.noop },
-       req, respBuilder, revertHandler, revertRB;
+       req, respBuilder;
 
    beforeEach(function() {
-      revertHandler = handler.__set__({
-         log: _.noop,
-      });
-      revertRB = ResponseBuilder.__set__({
-         log: _.noop,
-      });
-
       req = new Request({}, context);
       respBuilder = new ResponseBuilder();
-   });
-
-   afterEach(function() {
-      revertHandler();
-      revertRB();
    });
 
    it('calls the function and passes the response from its return value to the callback', function(done) {


### PR DESCRIPTION
This reverts the log changes from commit 89d9eaeadc9b3208553b9724acf89474f4fec662. As noted in #22, the binding of the `console.log` function on code initialization causes Lambda to log the incorrect `requestID` most of the time. The proper way to fix this would be to add a mockable logging library. However, that is out of scope at this time. Therefore, this commit removes the mock of `console.log` in the unit tests. Not the best for the developer, but removes the risk of unit test debug messages getting swallowed by an improperly mocked global `console.log`.