### PR TITLE
build: make peerDependencies into normal dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,8 +1097,7 @@
     "class.extend": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/class.extend/-/class.extend-0.9.2.tgz",
-      "integrity": "sha1-4cvaNpfLMdPNqxwAHSaQdckDH3g=",
-      "dev": true
+      "integrity": "sha1-4cvaNpfLMdPNqxwAHSaQdckDH3g="
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -2897,7 +2896,7 @@
     "http-status-codes": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.3.0.tgz",
-      "integrity": "sha1-nNDnE5F3PQZxtInUHLxQlKpBY7Y="
+      "integrity": "sha512-sI3sPmDZCe5paHlyCeIrf5z/tczPRz55QX5w0YtKamhdJ2VXyDRC6KI950I6q5Xw6/fzgd5mggHST/ENNhIcRw=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -3364,8 +3363,7 @@
     "jwt-simple": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.1.tgz",
-      "integrity": "sha1-eeoBiRth3mto4T5nwLS1vak3spQ=",
-      "dev": true
+      "integrity": "sha1-eeoBiRth3mto4T5nwLS1vak3spQ="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -4057,8 +4055,7 @@
     "q": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-      "dev": true
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "qs": {
       "version": "6.5.2",
@@ -5215,8 +5212,7 @@
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore.string": {
       "version": "3.3.5",
@@ -5296,8 +5292,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "url": "https://github.com/silvermine/apigateway-utils/issues"
   },
   "homepage": "https://github.com/silvermine/apigateway-utils#readme",
-  "peerDependencies": {
-    "class.extend": ">=0.9.2 <1.0.0",
-    "jwt-simple": ">=0.5.1 <1.0.0",
-    "underscore": ">=1.8.3 <2.0.0",
-    "uuid": ">=3.2.1 <4.0.0",
-    "q": ">=1.4.1 <2.0.0"
+  "dependencies": {
+    "class.extend": "0.9.2",
+    "jwt-simple": "0.5.1",
+    "underscore": "1.8.3",
+    "uuid": "3.2.1",
+    "q": "1.4.1",
+    "http-status-codes": "1.3.0"
   },
   "devDependencies": {
     "@silvermine/eslint-config": "3.0.0-rc.0",
@@ -50,8 +51,5 @@
     "sinon": "1.17.7",
     "underscore": "1.8.3",
     "uuid": "3.2.1"
-  },
-  "dependencies": {
-    "http-status-codes": "1.3.0"
   }
 }


### PR DESCRIPTION
Because this package was using peerDependendencies when it should be using regular
dependencies it is incompatible with projects that use non-compliant versions of those
packages.

The project that I'm working with uses another major version of uuid. Since this package
makes uuid a peer dependency, it will try to use the version I have installed, even though
it's incompatible. I don't see any downside to using normal dependencies rather than peer
dependencies besides some packages being duplicated, which is not much of a concern
for me at least. From what I understand, [peer dependencies are mostly used for creating
plugins](https://nodejs.org/en/blog/npm/peer-dependencies/), which this package is not doing.